### PR TITLE
changed 'extends Component' to 'extends React.Component'

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import {
   StyleSheet,
 } from 'react-native';
 
-export default class ImageButton extends Component {
+export default class ImageButton extends React.Component {
   constructor(props: {}) {
     super(props);
 
@@ -65,3 +65,4 @@ let styles = StyleSheet.create({
     height: null
   }
 });
+


### PR DESCRIPTION
When creating the class with extends Components, you get an error. To fix this use React.Component instead.